### PR TITLE
Customize the Edit Menu!

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "cf25ad6b94f02765d03b56d831794bbda3a3babd339e9cf04bd230e98b5dad2e",
+  "pins" : [
+    {
+      "identity" : "down",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/johnxnguyen/Down.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "e754ab1c80920dd51a8e08290c912ac1c2ac8b58"
+      }
+    },
+    {
+      "identity" : "highlightswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/appstefan/highlightswift.git",
+      "state" : {
+        "revision" : "1ee708afe9473828f36d0202722c9cc065d74110",
+        "version" : "1.0.7"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
+        "version" : "1.0.6"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Sources/SelectableMarkdownUI/View/AttributedTextView.swift
+++ b/Sources/SelectableMarkdownUI/View/AttributedTextView.swift
@@ -91,4 +91,9 @@ struct AttributedTextView: UIViewControllerRepresentable {
 public struct EditMenuAction {
     var label: String
     var action: (String) -> Void
+
+    public init(label: String, action: @escaping (String) -> Void) {
+        self.label = label
+        self.action = action
+    }
 }

--- a/Sources/SelectableMarkdownUI/View/SelectableMarkdownView.swift
+++ b/Sources/SelectableMarkdownUI/View/SelectableMarkdownView.swift
@@ -13,18 +13,23 @@ public struct SelectableMarkdownView: View {
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     @State private var formattedText: NSAttributedString
     @State private var messageHeight: CGFloat = 0
+
     let text: String
+    let editMenuActions: [ EditMenuAction ]?
+
     let styler: CodeStyler = CodeStyler.sharedInstance
     let down: Down
     
-    public init(text: String) {
+    public init(text: String, editMenuActions: [ EditMenuAction ]? = nil) {
         self.text = text
+        self.editMenuActions = editMenuActions
+
         self.down = Down(markdownString: text)
         self.formattedText = (try? down.toAttributedString(styler: styler)) ?? NSAttributedString(string: text)
     }
     
     public var body: some View {
-        AttributedTextView(text: formattedText) { newHeight in
+        AttributedTextView(text: formattedText, editMenuActions: editMenuActions) { newHeight in
             self.messageHeight = newHeight
         }
         .frame(height: messageHeight)
@@ -45,4 +50,22 @@ public struct SelectableMarkdownView: View {
             formattedText = refreshedFormattedText
         }
     }
+}
+
+#Preview("Simple") {
+    SelectableMarkdownView(text: "This is just a *simple* example")
+}
+
+#Preview("With Actions") {
+    SelectableMarkdownView(
+        text: "This is just a *simple* example",
+        editMenuActions: [
+            EditMenuAction(label: "Print Hightlight") {
+                print($0)
+            },
+            EditMenuAction(label: "Second one") {
+                print("Second: `\($0)`")
+            }
+        ]
+    )
 }


### PR DESCRIPTION
What are the odds that I'd find a SwiftUI project that creates a read-only TextEditor that presents Markdown well, and lets you select individual portions of text!?  The next step seems obvious - add custom actions to the Edit menu!

Hope this update works for you, and thanks for publishing this as open source!

(also, why can't SwiftUI do this stuff already???)